### PR TITLE
Introduces the ElasticClientFactory

### DIFF
--- a/src/main/java/at/medunigraz/imi/bst/config/TrecConfig.java
+++ b/src/main/java/at/medunigraz/imi/bst/config/TrecConfig.java
@@ -10,6 +10,11 @@ public final class TrecConfig {
     public static final String INDEX_NAME = "trec";
     public static final String MEDLINE_TYPE = "medline";
     public static final String TRIALS_TYPE = "trials";
+    
+    public static final String ELASTIC_HOSTNAME = "localhost";
+    public static final int ELASTIC_PORT = 9300;
+    
+    
 
 
     /* DATA - MEDLINE */

--- a/src/main/java/at/medunigraz/imi/bst/medline/Indexing.java
+++ b/src/main/java/at/medunigraz/imi/bst/medline/Indexing.java
@@ -1,20 +1,17 @@
 package at.medunigraz.imi.bst.medline;
 
-import at.medunigraz.imi.bst.config.TrecConfig;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.client.Client;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.transport.InetSocketTransportAddress;
-import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.transport.client.PreBuiltTransportClient;
 
-import java.net.InetAddress;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import at.medunigraz.imi.bst.config.TrecConfig;
+import at.medunigraz.imi.bst.trec.search.ElasticClientFactory;
 
 public class Indexing {
 
@@ -61,9 +58,7 @@ public class Indexing {
 
         long startTime = System.currentTimeMillis();
 
-        TransportAddress address = new InetSocketTransportAddress(InetAddress.getByName("localhost"), 9300);
-
-        Client client = new PreBuiltTransportClient(Settings.EMPTY).addTransportAddress(address);
+        Client client = ElasticClientFactory.getClient();
 
         BulkRequestBuilder bulkRequest = client.prepareBulk();
 

--- a/src/main/java/at/medunigraz/imi/bst/trec/search/ElasticClientFactory.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/search/ElasticClientFactory.java
@@ -1,0 +1,48 @@
+package at.medunigraz.imi.bst.trec.search;
+
+import java.io.Closeable;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.transport.client.PreBuiltTransportClient;
+
+import at.medunigraz.imi.bst.config.TrecConfig;
+
+public class ElasticClientFactory implements Closeable {
+
+	private static Client client = null;
+
+	public ElasticClientFactory() {
+	}
+
+	public static Client getClient() {
+		if (client == null) {
+			open();
+		}
+		return client;
+	}
+
+	@SuppressWarnings("resource")
+	private static void open() {
+		TransportAddress address;
+		try {
+			address = new InetSocketTransportAddress(InetAddress.getByName(TrecConfig.ELASTIC_HOSTNAME),
+					TrecConfig.ELASTIC_PORT);
+		} catch (UnknownHostException e) {
+			e.printStackTrace();
+			return;
+		}
+
+		client = new PreBuiltTransportClient(Settings.EMPTY).addTransportAddress(address);
+	}
+
+	public void close() {
+		client.close();
+		client = null;
+	}
+
+}

--- a/src/test/java/at/medunigraz/imi/bst/trec/search/ElasticClientFactoryTest.java
+++ b/src/test/java/at/medunigraz/imi/bst/trec/search/ElasticClientFactoryTest.java
@@ -1,0 +1,57 @@
+package at.medunigraz.imi.bst.trec.search;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.io.IOException;
+import java.net.Socket;
+
+import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.junit.Assume;
+import org.junit.Test;
+
+import at.medunigraz.imi.bst.config.TrecConfig;
+
+public class ElasticClientFactoryTest {
+
+	public ElasticClientFactoryTest() {
+		// There must be an available server
+		Assume.assumeTrue(checkOpenPort(TrecConfig.ELASTIC_HOSTNAME, TrecConfig.ELASTIC_PORT));
+	}
+
+	@Test
+	public void testGetClient() {
+		Client client = ElasticClientFactory.getClient();
+
+		ClusterHealthResponse health = client.admin().cluster().prepareHealth().get();
+		String actual = health.getClusterName();
+		assertEquals("elasticsearch", actual); // Any check
+	}
+
+	@Test
+	public void testHealth() {
+		Client client = ElasticClientFactory.getClient();
+
+		ClusterHealthResponse health = client.admin().cluster().prepareHealth().get();
+		ClusterHealthStatus status = health.getStatus();
+		int actual = status.compareTo(ClusterHealthStatus.RED);
+		assertNotEquals(0, actual); // 0 = RED
+	}
+
+	/**
+	 * Checks whether a given port is open on a server
+	 * 
+	 * @param hostname
+	 * @param port
+	 * @return
+	 */
+	private boolean checkOpenPort(String hostname, int port) {
+		try (Socket ignored = new Socket(hostname, port)) {
+			return true;
+		} catch (IOException ignored) {
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
- The factory centralizes the work of setting up a client to connect to
a Elastic Search instance.
- Host and port config are now centralized in TrecConfig.
- When the server is available, tests are run to ensure the connection
is OK. Additionally, the cluster health is also checked and tests fail
if status is RED.
- Also changes the Indexing class so that it uses the factory.