### PR TITLE
Refactors code to use ResultList only when needed (closes #49)

### DIFF
--- a/src/main/java/at/medunigraz/imi/bst/trec/model/ResultList.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/model/ResultList.java
@@ -15,7 +15,16 @@ public class ResultList {
 	public boolean add(Result result) {
 		return results.add(result);
 	}
-	
+
+	/**
+	 * 
+	 * @deprecated Use add(Result result) instead
+	 * @param results
+	 */
+	public void setResults(List<Result> results) {
+		this.results = results;
+	}
+
 	public Topic getTopic() {
 		return topic;
 	}

--- a/src/main/java/at/medunigraz/imi/bst/trec/query/ElasticSearchQuery.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/query/ElasticSearchQuery.java
@@ -1,8 +1,10 @@
 package at.medunigraz.imi.bst.trec.query;
 
+import java.util.List;
+
 import org.json.JSONObject;
 
-import at.medunigraz.imi.bst.trec.model.ResultList;
+import at.medunigraz.imi.bst.trec.model.Result;
 import at.medunigraz.imi.bst.trec.model.Topic;
 import at.medunigraz.imi.bst.trec.search.ElasticSearch;
 
@@ -16,7 +18,7 @@ public class ElasticSearchQuery implements Query {
 	}
 
 	@Override
-	public ResultList query() {
+	public List<Result> query() {
 		ElasticSearch es = new ElasticSearch();
 		return es.query(jsonQuery);
 	}

--- a/src/main/java/at/medunigraz/imi/bst/trec/query/Query.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/query/Query.java
@@ -1,10 +1,12 @@
 package at.medunigraz.imi.bst.trec.query;
 
-import at.medunigraz.imi.bst.trec.model.ResultList;
+import java.util.List;
+
+import at.medunigraz.imi.bst.trec.model.Result;
 import at.medunigraz.imi.bst.trec.model.Topic;
 
 public interface Query {
-	public ResultList query();
+	public List<Result> query();
 	
 	public Topic getTopic();
 	

--- a/src/main/java/at/medunigraz/imi/bst/trec/query/QueryDecorator.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/query/QueryDecorator.java
@@ -1,6 +1,8 @@
 package at.medunigraz.imi.bst.trec.query;
 
-import at.medunigraz.imi.bst.trec.model.ResultList;
+import java.util.List;
+
+import at.medunigraz.imi.bst.trec.model.Result;
 import at.medunigraz.imi.bst.trec.model.Topic;
 
 public class QueryDecorator implements Query {
@@ -12,7 +14,7 @@ public class QueryDecorator implements Query {
 	}
 
 	@Override
-	public ResultList query() {
+	public List<Result> query() {
 		return decoratedQuery.query();
 	}
 	

--- a/src/main/java/at/medunigraz/imi/bst/trec/query/TemplateQueryDecorator.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/query/TemplateQueryDecorator.java
@@ -2,11 +2,12 @@ package at.medunigraz.imi.bst.trec.query;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
 
-import at.medunigraz.imi.bst.trec.model.ResultList;
+import at.medunigraz.imi.bst.trec.model.Result;
 import at.medunigraz.imi.bst.trec.model.Topic;
 
 public class TemplateQueryDecorator extends QueryDecorator {
@@ -19,7 +20,7 @@ public class TemplateQueryDecorator extends QueryDecorator {
 	}
 
 	@Override
-	public ResultList query() {
+	public List<Result> query() {
 		applyTemplate();
 		return decoratedQuery.query();
 	}

--- a/src/main/java/at/medunigraz/imi/bst/trec/search/SearchEngine.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/search/SearchEngine.java
@@ -1,19 +1,41 @@
 package at.medunigraz.imi.bst.trec.search;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
+import org.json.JSONObject;
+
+import at.medunigraz.imi.bst.trec.model.Result;
 import at.medunigraz.imi.bst.trec.model.ResultList;
 import at.medunigraz.imi.bst.trec.model.Topic;
 import at.medunigraz.imi.bst.trec.model.TopicSet;
 
 public interface SearchEngine {
-	public ResultList query(Topic topic);
+	public List<Result> query(JSONObject jsonQuery);
+	
+	/**
+	 * 
+	 * @deprecated Use decorators instead
+	 * @param topic
+	 * @return
+	 */
+	public List<Result> query(Topic topic);
 
+	/**
+	 * 
+	 * @deprecated Use decorators instead
+	 * @param topicSet
+	 * @return
+	 */
 	default public Set<ResultList> query(TopicSet topicSet) {
 		Set<ResultList> ret = new HashSet<>();
 		for (Topic topic : topicSet.getTopics()) {
-			ret.add(query(topic));
+			List<Result> results = query(topic);
+			
+			ResultList resultList = new ResultList(topic);
+			resultList.setResults(results);
+			ret.add(resultList);
 		}
 		return ret;
 	}

--- a/src/test/java/at/medunigraz/imi/bst/trec/query/DummyElasticSearchQuery.java
+++ b/src/test/java/at/medunigraz/imi/bst/trec/query/DummyElasticSearchQuery.java
@@ -1,6 +1,8 @@
 package at.medunigraz.imi.bst.trec.query;
 
-import at.medunigraz.imi.bst.trec.model.ResultList;
+import java.util.List;
+
+import at.medunigraz.imi.bst.trec.model.Result;
 import at.medunigraz.imi.bst.trec.model.Topic;
 
 public class DummyElasticSearchQuery extends ElasticSearchQuery {
@@ -10,7 +12,7 @@ public class DummyElasticSearchQuery extends ElasticSearchQuery {
 	}
 
 	@Override
-	public ResultList query() {
+	public List<Result> query() {
 		// NOOP
 		return null;
 	}

--- a/src/test/java/at/medunigraz/imi/bst/trec/query/QueryDecoratorTest.java
+++ b/src/test/java/at/medunigraz/imi/bst/trec/query/QueryDecoratorTest.java
@@ -4,9 +4,12 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
+import java.util.List;
+
 import org.junit.Assume;
 import org.junit.Test;
-import at.medunigraz.imi.bst.trec.model.ResultList;
+
+import at.medunigraz.imi.bst.trec.model.Result;
 import at.medunigraz.imi.bst.trec.utils.ConnectionUtils;
 
 public abstract class QueryDecoratorTest {
@@ -16,10 +19,10 @@ public abstract class QueryDecoratorTest {
 	@Test
 	public void testLiveQuery() {
 		Assume.assumeTrue(ConnectionUtils.checkElasticOpenPort());
-		ResultList resultList = decoratedQuery.query();
+		List<Result> resultList = decoratedQuery.query();
 		
-		assertFalse(resultList.getResults().isEmpty());
-		assertThat(resultList.getResults().size(), greaterThan(10));
+		assertFalse(resultList.isEmpty());
+		assertThat(resultList.size(), greaterThan(10));
 	}
 
 }

--- a/src/test/java/at/medunigraz/imi/bst/trec/search/ElasticSearchTest.java
+++ b/src/test/java/at/medunigraz/imi/bst/trec/search/ElasticSearchTest.java
@@ -28,10 +28,7 @@ public class ElasticSearchTest {
 		File simple = new File(getClass().getResource("/templates/match-title-thyroid.json").getFile());
 		String jsonQuery = FileUtils.readFileToString(simple, "UTF-8");
 
-		// TODO This is actually not needed here, so remove it from the API
-		Topic topic = new Topic();
-
-		List<Result> results = es.query(topic, new JSONObject(jsonQuery)).getResults();
+		List<Result> results = es.query(new JSONObject(jsonQuery));
 
 		assertFalse(results.isEmpty());
 	}
@@ -40,7 +37,7 @@ public class ElasticSearchTest {
 	public void testQuery() {
 		ElasticSearch es = new ElasticSearch();
 
-		List<Result> results = es.query(new Topic().withDisease("thyroid")).getResults();
+		List<Result> results = es.query(new Topic().withDisease("thyroid"));
 
 		assertFalse(results.isEmpty());
 	}


### PR DESCRIPTION
So far, most of the code dealing with results is accessing the
List<Result> directly. It's quite cumbersome to keep calling
.getResults() in the ResultList object and to mock topics for testing.

Therefore, this commit refactors the code to use the ResultList object
only when needed, i.e. when querying a TopicSet and writing results with
TrecWriter.