### PR TITLE
Adds a new default template

### DIFF
--- a/src/main/java/at/medunigraz/imi/bst/trec/RunnerDemo.java
+++ b/src/main/java/at/medunigraz/imi/bst/trec/RunnerDemo.java
@@ -29,7 +29,7 @@ public class RunnerDemo {
 	public static void main(String[] args) {
 		String[] pmRuns = { "example-pmid", "extra-pmid", "topics2017-pmid" };
 		
-		final File pmTemplate = new File(RunnerDemo.class.getResource("/templates/must-match-disease.json").getFile());
+		final File pmTemplate = new File(RunnerDemo.class.getResource("/templates/must-match-gene.json").getFile());
 		Gene.Field[] expandTo = { Gene.Field.SYMBOL, Gene.Field.DESCRIPTION };
 		Query pmDecorator = new WordRemovalQueryDecorator(
 				new TemplateQueryDecorator(pmTemplate, new ElasticSearchQuery("trec")));

--- a/src/main/resources/templates/must-match-gene.json
+++ b/src/main/resources/templates/must-match-gene.json
@@ -1,0 +1,84 @@
+{
+	"bool": {
+		"must": [
+			{
+				"multi_match": {
+					"query": "{{disease}}",
+					"fields": [
+						"title^2",
+						"abstract",
+						"keyword",
+						"meshTags"
+					],
+					"tie_breaker": 0.3,
+					"type": "best_fields",
+					"boost": 1
+				}
+			},
+			{
+				"multi_match": {
+					"query": "{{gene}}",
+					"fields": [
+						"title^2",
+						"abstract",
+						"keyword",
+						"meshTags"
+					],
+					"tie_breaker": 0.3,
+					"type": "best_fields"
+				}
+			}
+		],
+		"should": [
+			{
+				"bool": {
+					"should": {
+						"multi_match": {
+							"query": "cancer carcinoma tumor",
+							"fields": [
+								"title^2",
+								"abstract",
+								"keyword",
+								"meshTags"
+							],
+							"tie_breaker": 0.3,
+							"type": "best_fields"
+						}
+					}
+				}
+			},
+			{
+				"bool": {
+					"should": {
+						"multi_match": {
+							"query": "gene genotype DNA base",
+							"fields": [
+								"title^2",
+								"abstract",
+								"keyword",
+								"meshTags"
+							],
+							"tie_breaker": 0.3,
+							"type": "best_fields"
+						}
+					}
+				}
+			},
+			{
+				"bool": {
+					"should": {
+						"multi_match": {
+							"query": "prognosis prognostic therapy treatment case report patient results",
+							"fields": [
+								"title^2",
+								"abstract"
+							],
+							"tie_breaker": 0.3,
+							"type": "best_fields"
+						}
+					}
+				}
+			}
+		]
+	}
+}


### PR DESCRIPTION
According to the guidelines, the gene MUST match so that the document
can be considered relevant.

This updates the ES query to reflect that.