### PR TITLE
Adds 'publicationYear' as a separate field (refs #74)

### DIFF
--- a/src/main/java/at/medunigraz/imi/bst/extraabstracts/Indexing.java
+++ b/src/main/java/at/medunigraz/imi/bst/extraabstracts/Indexing.java
@@ -52,6 +52,7 @@ public class Indexing {
                             .field("pubmedId", StringEscapeUtils.escapeJson(article.pubMedId))
                             .field("title", StringEscapeUtils.escapeJson(article.docTitle))
                             .field("publicationDate", StringEscapeUtils.escapeJson(StringEscapeUtils.escapeJson((article.publicationYear))))
+                            .field("publicationYear", StringEscapeUtils.escapeJson(article.publicationYear))
                             .field("abstract", StringEscapeUtils.escapeJson(article.docAbstract))
                             .endObject()
                     )

--- a/src/main/java/at/medunigraz/imi/bst/medline/Indexing.java
+++ b/src/main/java/at/medunigraz/imi/bst/medline/Indexing.java
@@ -62,6 +62,7 @@ public class Indexing {
                             .field("title", StringEscapeUtils.escapeJson(article.docTitle))
                             .field("publicationDate", StringEscapeUtils.escapeJson(article.publicationMonth +
                                                              " " + StringEscapeUtils.escapeJson((article.publicationYear))))
+                            .field("publicationYear", StringEscapeUtils.escapeJson(article.publicationYear))
                             .field("abstract", StringEscapeUtils.escapeJson(article.docAbstract))
                             .field("meshTags", article.meshTags)
                             .endObject()


### PR DESCRIPTION
So that it can be indexed as int/long and then we can use decay
functions for ranking as an experiment.